### PR TITLE
feat: add goreleaser manifests

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -1,0 +1,34 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+  packages: write
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v6
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          install-only: true
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: 'latest'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_AUTH_TOKEN: ${{ secrets.GORELEASER_AUTH_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ go.work.sum
 # project
 log.txt
 *.log
+
+#gorelease output folder
+/dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ homebrew_casks:
       post:
         install: |
           if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/freight"]
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/scorebug"]
           end
 
     repository:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+version: 2
+
+builds:
+  - id: "scorebug"
+    main: "./cmd/scorebug"
+    binary: "scorebug"
+
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    flags:
+      - -trimpath
+    ignore:
+      - goos: windows
+        goarch: arm
+    ldflags:
+      - -s -w
+
+archives:
+  - formats: ['tar.gz']
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: ['zip']
+
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: KevinStirling
+    name: scorebug.sh
+
+homebrew_casks:
+  - name: scorebug
+
+    commit_author:
+      name: KevinStirling
+      email: TODO
+
+    homepage: "https://github.com/KevinStirling/scorebug.sh"
+    description: "Live MLB scores in your terminal"
+    license: "MIT"
+    url:
+      verified: github.com/KevinStirling/scorebug.sh
+
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/freight"]
+          end
+
+    repository:
+      owner: KevinStirling
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.GORELEASER_AUTH_TOKEN }}"


### PR DESCRIPTION
Partially addresses https://github.com/KevinStirling/scorebug.sh/issues/16


This PR will add goreleaser to scorebug and it will do the following

- create binaries + archives for each cut tag
- make scorebug a homebrew cask and publish it to homebrew-tap (this would need to be created)


Couple of caveats 

- This will only run when a tag is pushed/cut on the repo. The release prcess (i.e release-please) would have to be done separate from this PR. For now if you just cut a tag and git push it or make it manually this will then run
- the hombrew-tap repo needs to be created. This is a specific repo that goreleaser will publish your homebrew casks (see https://github.com/devbytes-cloud/homebrew-tap)
- You will need to create a fine grained token/GH Secret called "GORELEASER_AUTH_TOKEN" this token will need to have access to write to the homebrew-tap repo

Output from running `goreleaser release --skip=publish --snapshot`

```
☸ orbstack in scorebug.sh on  dd/release-please [!+] via 🐹 v1.26.3 
❯ goreleaser release --skip=publish --snapshot
  • starting release
  • skipping announce, publish, and validate...
  • loading environment variables
  • getting and validating git state

    • ignoring errors because this is a snapshot     error=git doesn't contain any tags - either add a tag or use --snapshot
    • using tags                                     previous=<unknown> current=v0.0.0
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.0-SNAPSHOT-8b2968f
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       paths=cmd/scorebug binaries=scorebug target=windows_arm64_v8.0
    • building                                       paths=cmd/scorebug binaries=scorebug target=linux_amd64_v1
    • building                                       paths=cmd/scorebug binaries=scorebug target=darwin_arm64_v8.0
    • building                                       paths=cmd/scorebug binaries=scorebug target=linux_arm_6
    • building                                       paths=cmd/scorebug binaries=scorebug target=windows_amd64_v1
    • building                                       paths=cmd/scorebug binaries=scorebug target=darwin_amd64_v1
    • building                                       paths=cmd/scorebug binaries=scorebug target=linux_arm64_v8.0
      • took: 12s
  • archives
    • archiving                                      name=dist/scorebug.sh_Linux_arm64.tar.gz
    • archiving                                      name=dist/scorebug.sh_Darwin_x86_64.tar.gz
    • archiving                                      name=dist/scorebug.sh_Linux_armv6.tar.gz
    • archiving                                      name=dist/scorebug.sh_Windows_arm64.zip
    • archiving                                      name=dist/scorebug.sh_Linux_x86_64.tar.gz
    • archiving                                      name=dist/scorebug.sh_Darwin_arm64.tar.gz
    • archiving                                      name=dist/scorebug.sh_Windows_x86_64.zip
  • calculating checksums
  • homebrew cask
    • writing                                        cask=dist/homebrew/Casks/scorebug.rb
  • writing artifacts metadata
  • release succeeded after 12s
  • thanks for using GoReleaser!
  
  ```